### PR TITLE
Give time to twingate to start before checking its status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ runs:
       run: |
         echo '${{ inputs.service-key }}' | sudo twingate setup --headless=-
         sudo twingate start
+        sleep 3 # Give some time to twingate to start
         TWINGATE_STATUS=$(sudo twingate status)
         if [[ "$TWINGATE_STATUS" != 'online' ]]; then
           echo "Exiting with error as Twingate is not connected"


### PR DESCRIPTION
Added a sleep after starting twingate to allow it to finish starting before checking for its status.