### PR TITLE
Resolve twingate connection issue for self-hosted runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,7 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          sudo twingate start | tee twingate.log
-          sudo cat twingate.log
+          sudo twingate start
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,6 @@ runs:
         sudo twingate status
         sudo twingate config log-level debug
         curl -I https://billhop.twingate.com
-        ping -c 4 billhop.twingate.com
 
         MAX_RETRIES=5
         WAIT_TIME=5

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,22 @@ runs:
         sudo apt update
         sudo apt install -yq twingate
         sudo twingate --version
+
+    - name: Gather information from GitHub-hosted runner
+      run: |
+        id
+        sudo -l
+        env
+        twingate --version || echo "Twingate not installed"
+        docker --version || echo "Docker not installed"
+        uname -a
+        ip addr
+        ip route
+        cat /etc/resolv.conf
+        sestatus || echo "SELinux not available"
+        sudo aa-status || echo "AppArmor not available"
+        ulimit -a
+
     - name: Setup and start Twingate
       shell: bash
       run: |
@@ -29,12 +45,11 @@ runs:
         MAX_RETRIES=5
         WAIT_TIME=5
         n=0
-        echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
-        sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
+        
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
           set +e
-          
+          sudo twingate start
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 
@@ -54,8 +69,10 @@ runs:
           echo "Twingate service is not connected. Retrying ..."
         done
 
-        sudo cat /var/log/twingate/twingate.log
-
+        # Search for Twingate logs in the system
+        sudo find / -name '*twingate*.log' 2>/dev/null
+        # Check system logs for Twingate-related messages
+        sudo dmesg | grep -i twingate
         if [ $n -eq $MAX_RETRIES ]; then
           echo "Twingate service failed to connect."
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,8 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          /usr/bin/twingate start
-          
+          sudo twingate start
+
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
           set +e
-          sudo twingate start
+          twingate start
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
+          curl -I https://billhop.twingate.com
           sudo twingate start | tee twingate.log
           sudo cat twingate.log
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."

--- a/action.yml
+++ b/action.yml
@@ -24,21 +24,14 @@ runs:
       shell: bash
       run: |
         echo '${{ inputs.service-key }}' | sudo twingate setup --headless=-
-        sudo twingate status
-        sudo twingate config log-level debug
-        curl -I https://billhop.twingate.com
-
         MAX_RETRIES=5
         WAIT_TIME=5
         n=0
-        # echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
-        # sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
+
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          set +e
-          #sudo twingate start
-          echo "user" && whoami
           /usr/bin/twingate start
+          
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 
@@ -58,10 +51,6 @@ runs:
           echo "Twingate service is not connected. Retrying ..."
         done
 
-        # Search for Twingate logs in the system
-        sudo find / -name '*twingate*.log' 2>/dev/null
-        # Check system logs for Twingate-related messages
-        sudo dmesg | grep -i twingate
         if [ $n -eq $MAX_RETRIES ]; then
           echo "Twingate service failed to connect."
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -19,21 +19,6 @@ runs:
         sudo apt install -yq twingate
         sudo twingate --version
 
-    - name: Gather information from runner
-      shell: bash
-      run: |
-        id
-        sudo -l
-        env
-        twingate --version || echo "Twingate not installed"
-        docker --version || echo "Docker not installed"
-        command -v uname || echo "uname not found"
-        command -v ip || echo "ip not found"
-        command -v route || echo "route not found"
-        command -v cat || echo "cat not found"
-        command -v sestatus || echo "sestatus not found"
-        command -v aa-status || echo "aa-status not found"
-
 
     - name: Setup and start Twingate
       shell: bash
@@ -46,11 +31,14 @@ runs:
         MAX_RETRIES=5
         WAIT_TIME=5
         n=0
-        
+        echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
+        sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
           set +e
-          sudo twingate start
+          #sudo twingate start
+          echo "user" && whoami
+          /usr/bin/twingate start
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
         MAX_RETRIES=5
         WAIT_TIME=5
         n=0
-        echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
-        sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
+        # echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
+        # sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
           set +e

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,6 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          curl -I https://billhop.twingate.com
           sudo twingate start | tee twingate.log
           sudo cat twingate.log
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."

--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,8 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          sudo twingate start
-
+          /usr/bin/twingate start
+          
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -22,17 +22,20 @@ runs:
       shell: bash
       run: |
         echo '${{ inputs.service-key }}' | sudo twingate setup --headless=-
+        sudo twingate status
         sudo twingate config log-level debug
+        curl -I https://billhop.twingate.com
+        ping -c 4 billhop.twingate.com
 
         MAX_RETRIES=5
         WAIT_TIME=5
         n=0
-
+        echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
+        sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
           set +e
-          echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
-          sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
+          
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 
@@ -52,7 +55,7 @@ runs:
           echo "Twingate service is not connected. Retrying ..."
         done
 
-        ls -la /var/log/twingated.log && cat /var/log/twingated.log
+        sudo cat /var/log/twingate/twingate.log
 
         if [ $n -eq $MAX_RETRIES ]; then
           echo "Twingate service failed to connect."

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
+          set +e
           sudo twingate start
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,9 @@ runs:
       run: |
         echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
         sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/twingate.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+        sudo apt update
         sudo apt install -yq twingate
+        sudo twingate --version
     - name: Setup and start Twingate
       shell: bash
       run: |
@@ -26,8 +28,8 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          sudo twingate start
-
+          sudo twingate start | tee twingate.log
+          sudo cat twingate.log
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,8 @@ runs:
         sudo apt install -yq twingate
         sudo twingate --version
 
-    - name: Gather information from GitHub-hosted runner
+    - name: Gather information from runner
+      shell: bash
       run: |
         id
         sudo -l

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ runs:
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
           set +e
-          twingate start
+          echo "$(id -un) ALL=(ALL) NOPASSWD:/usr/bin/twingate start" | sudo tee /etc/sudoers.d/$(id -un)-twingate
+          sudo chmod 0440 /etc/sudoers.d/$(id -un)-twingate
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 

--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,13 @@ runs:
         env
         twingate --version || echo "Twingate not installed"
         docker --version || echo "Docker not installed"
-        uname -a
-        ip addr
-        ip route
-        cat /etc/resolv.conf
-        sestatus || echo "SELinux not available"
-        sudo aa-status || echo "AppArmor not available"
-        ulimit -a
+        command -v uname || echo "uname not found"
+        command -v ip || echo "ip not found"
+        command -v route || echo "route not found"
+        command -v cat || echo "cat not found"
+        command -v sestatus || echo "sestatus not found"
+        command -v aa-status || echo "aa-status not found"
+
 
     - name: Setup and start Twingate
       shell: bash


### PR DESCRIPTION
Issue Encountered: The self-hosted runner (running in Kubernetes) was not functioning.

Solution: 
1. add sudo apt update
2. Replaced `sudo twingate start `with /usr/bin/twingate start`.

Outcome: This change resolved the issue, and now both the self-hosted and GitHub-hosted runners are working properly.