### PR TITLE
Twingate startup issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
+          set +e
           /usr/bin/twingate start
           
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ runs:
       run: |
         echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
         sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/twingate.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+        sudo apt update
         sudo apt install -yq twingate
     - name: Setup and start Twingate
       shell: bash
@@ -26,8 +27,8 @@ runs:
 
         while [ $n -lt $MAX_RETRIES ]; do
           echo "Starting Twingate service..."
-          sudo twingate start
-
+          /usr/bin/twingate start
+          
           echo "Waiting $WAIT_TIME seconds for Twingate service to start..."
           sleep $WAIT_TIME
 


### PR DESCRIPTION
Issue Encountered: The self-hosted runner (running in Kubernetes) was not functioning.
Also resolve the issue: https://github.com/Twingate/github-action/issues/7
Solution: 
1. add sudo apt update
2. Replaced `sudo twingate start `with /usr/bin/twingate start`.

Outcome: This change resolved the issue, and now verified both the self-hosted and GitHub-hosted runners are working properly.