### PR TITLE
Support Windows Runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,13 +10,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Twingate
+    - name: Install Twingate (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
         sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/twingate.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
         sudo apt install -yq twingate
-    - name: Setup and start Twingate
+    - name: Setup and start Twingate (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         echo '${{ inputs.service-key }}' | sudo twingate setup --headless=-
@@ -51,3 +53,20 @@ runs:
           echo "Twingate service failed to connect."
           exit 1
         fi
+
+    - name: Install and Start Twingate (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+          Invoke-WebRequest https://api.twingate.com/download/windows?installer=msi -OutFile .\twingate_client.msi
+          
+          Set-Content .\key.json  '${{ inputs.service-key }}'
+          $key_path = (Get-Item .\key.json | Resolve-Path).ProviderPath
+          
+          .\twingate_client.msi service_secret=$key_path /qn
+
+          Start-Sleep -Seconds 30
+          Get-Service twingate.service
+          Start-Service twingate.service
+          Start-Sleep -Seconds 10
+          Get-Service twingate.service

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Error if unsupported runner.os
+      if: runner.os != 'Linux' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        echo "Unsupported Runner OS: ${{ runner.os }}"
+        exit 1
+
     - name: Install Twingate (Linux)
       if: runner.os == 'Linux'
       shell: bash
@@ -62,7 +69,7 @@ runs:
           
           Set-Content .\key.json  '${{ inputs.service-key }}'
           $key_path = (Get-Item .\key.json | Resolve-Path).ProviderPath
-          
+
           .\twingate_client.msi service_secret=$key_path /qn
 
           Start-Sleep -Seconds 30


### PR DESCRIPTION
This adds a windows specific step to install the twingate client on windows runners. Also added an indication when the OS is unsupported by this action (most likely OSX).

This PR is based on the work at https://github.com/Twingate-Labs/headless-windows/blob/main/.github/workflows/windows_headless_example.yml