### PR TITLE
chore: Remove support for ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       strategy:
         max-parallel: 4
         matrix:
-          runs-on: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, ubuntu-24.04-arm, ubuntu-22.04-arm]
+          runs-on: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm]
           include:
             - runs-on: ubuntu-latest
               service-key: SERVICE_KEY
@@ -19,8 +19,6 @@ jobs:
               service-key: SERVICE_KEY1
             - runs-on: ubuntu-22.04
               service-key: SERVICE_KEY2
-            - runs-on: ubuntu-20.04
-              service-key: SERVICE_KEY3
             - runs-on: ubuntu-24.04-arm
               service-key: SERVICE_KEY_ARM1
             - runs-on: ubuntu-22.04-arm


### PR DESCRIPTION
Github is deprecating support for Ubuntu 20.04 on April 1st. Removing support for Ubuntu 20.04.