### PR TITLE
feat: Add configurable max retries and initial wait time

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,14 @@ inputs:
   service-key:
     description: 'Twingate Service Key'
     required: true
+  initial-wait-time:
+    description: 'Initial wait time in seconds before retrying Twingate connection. Defaults to 5.'
+    required: false
+    default: '5'
+  max-retries:
+    description: 'Maximum number of retry attempts if the Twingate service fails to connect. Defaults to 5.'
+    required: false
+    default: '5'
 runs:
   using: "composite"
   steps:
@@ -31,8 +39,8 @@ runs:
       shell: bash
       run: |
         echo '${{ inputs.service-key }}' | sudo twingate setup --headless -
-        MAX_RETRIES=5
-        WAIT_TIME=5
+        MAX_RETRIES=${{ inputs.max-retries }}
+        WAIT_TIME=${{ inputs.initial-wait-time }}
         n=0
 
         while [ $n -lt $MAX_RETRIES ]; do


### PR DESCRIPTION
### **Added Inputs**  

1. **Input Name:** `initial-wait-time`  
   **Description:** `Initial wait time in seconds before retrying Twingate connection. Defaults to 5.`  

2. **Input Name:** `max-retries`  
   **Description:** `Maximum number of retry attempts if the Twingate service fails to connect. Defaults to 5.`  

### **PR Description**  

**Description:**  
This PR introduces two new input parameters, `initial-wait-time` and `max-retries`, allowing users to configure the initial wait time before retrying the Twingate connection and the maximum number of retry attempts. Previously, these values were hardcoded to 5 seconds and 5 retries.  

**Changes:**  
- Added `initial-wait-time` input with a default value of 5.  
- Added `max-retries` input with a default value of 5.  
- Replaced the hardcoded `WAIT_TIME=5` with `WAIT_TIME=${{ inputs.initial-wait-time }}`.  
- Replaced the hardcoded `MAX_RETRIES=5` with `MAX_RETRIES=${{ inputs.max-retries }}`.  

**Why this change?**  
- Provides flexibility for users to adjust the retry behavior based on network conditions.  
- Helps optimize connection stability by allowing longer or shorter wait times.  
- Enables users to control the number of retries instead of relying on a fixed value.  

**Impact:**  
- Backward compatible as the default values remain the same (5 seconds and 5 retries).  
- Users can now fine-tune retry logic to improve Twingate connection reliability.