### PR TITLE
fix: Windows CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
             - runs-on: ubuntu-22.04-arm
               service-key: SERVICE_KEY_ARM2
       runs-on: ${{ matrix.runs-on }}
+      timeout-minutes: 3
       steps:
         - uses: actions/checkout@v4
 
@@ -93,6 +94,7 @@ jobs:
             - runs-on: windows-2022
               service-key: SERVICE_KEY_WIN3
       runs-on: ${{ matrix.runs-on }}
+      #timeout-minutes: 6
       steps:
         - uses: actions/checkout@v4
 
@@ -105,7 +107,10 @@ jobs:
         - uses: ./.github/actions/test
           with:
             service-key: ${{ secrets[matrix.service-key] }}
-  
+
+        - name: Open live SSH session (Windows)
+          uses: mxschmitt/action-tmate@v3
+
         - name: Access a secure resource
           shell: powershell
           env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
             - runs-on: windows-2022
               service-key: SERVICE_KEY_WIN3
       runs-on: ${{ matrix.runs-on }}
-      #timeout-minutes: 6
+      timeout-minutes: 6
       steps:
         - uses: actions/checkout@v4
 
@@ -108,16 +108,13 @@ jobs:
           with:
             service-key: ${{ secrets[matrix.service-key] }}
 
-        - name: Open live SSH session (Windows)
-          uses: mxschmitt/action-tmate@v3
-
         - name: Access a secure resource
           shell: powershell
           env:
             TEST_URL: http://business.prod.beamreachinc.int/
           run: |
             Write-Host "Calling $env:TEST_URL 🚀"
-            Invoke-WebRequest -Uri $env:TEST_URL -Verbose
+            Invoke-WebRequest -Uri $env:TEST_URL -Verbose -TimeoutSec 10 -UseBasicParsing
 
         - name: Print client logs
           shell: powershell


### PR DESCRIPTION
The main fix of the PR is updating the PowerShell web request command with a basic parsing option, as without it, the parsing would halt the job.

I've also added job-specific timeouts for Ubuntu and Windows runners to ensure that the jobs don't run indefinitely.