### PR TITLE
fix(action.yml): lock timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,17 +21,20 @@ runs:
         echo "Unsupported Runner OS: ${{ runner.os }}"
         exit 1
 
+    - name: Update System (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt -o DPkg::Lock::Timeout=-1 update
+        echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
+        sudo apt-get update -o DPkg::Lock::Timeout=-1 -o Dir::Etc::sourcelist="sources.list.d/twingate.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
     - name: Install Twingate (Linux)
       if: runner.os == 'Linux'
       shell: bash
       run: |
         ps aux | grep '[a]pt'
         sudo service packagekit restart
-        sudo apt -o DPkg::Lock::Timeout=-1 update
-        echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
-        sudo apt-get update -o DPkg::Lock::Timeout=-1 -o Dir::Etc::sourcelist="sources.list.d/twingate.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
         sudo apt -o DPkg::Lock::Timeout=-1 install -yq twingate
-    
     - name: Setup and start Twingate (Linux)
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
Getting process locks when running matrix in self hosted runner
```sh
Reading package lists...
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 1147 (python)
E: Unable to lock directory /var/lib/apt/lists/
Error: Process completed with exit code 100.
```
