### PR TITLE
fix: more resilient apt commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
         done
     
         # Install Twingate
-        sudo apt-get -o DPkg::Lock::Timeout=60 install -y twingate
+        sudo apt-get -yq -o DPkg::Lock::Timeout=60 install twingate
     
     - name: Setup and start Twingate (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
We use self-hosted runners and have found that sometimes another process (probably apt-daily) has a lock and causes the `apt update` in this action to fail. Adding an exponential backoff provides more resilience for the action. Adding the `-o DPkg::Lock::Timeout=60` provides additional resilience so it won't fail immediately if another dpkg process is running.