### PR TITLE
feat(action.yml): add caching option for Twingate .deb packages to speed up installation process

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,37 +112,22 @@ runs:
       shell: powershell
       run: |
         $uri = "https://api.twingate.com/download/windows?installer=msi"
-        try {
-            # Make request without following redirects
-            $response = Invoke-WebRequest -Uri $uri -Method Get -MaximumRedirection 0 -ErrorAction Stop
-        }
-        catch {
-            # When MaximumRedirection = 0, PowerShell throws on 302 — grab the response anyway
-            $response = $_.Exception.Response
-        }
 
-        if (-not $response) {
-         throw "No HTTP response received"
-        }
-        if ($response.StatusCode -ne 302) {
-         throw "Expected HTTP 302, got $($response.StatusCode)"
-        }
+        # Follow the redirect and get the final URL
+        $response = Invoke-WebRequest -Uri $uri -Method Head -UseBasicParsing
+        $finalUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
 
-        # Extract Location header
-        $location = $response.Headers['Location']
-        if (-not $location) {
-          throw "Missing Location header"
-        }
+        Write-Host "Final URL: $finalUrl"
 
         # Extract version from URL
         # Example:
         # https://binaries.twingate.com/client/windows/versions/2025.338.1789/TwingateWindowsInstaller.msi
-        if ($location -match "https://binaries.twingate.com/client/windows/versions/([^/]+)/") {
+        if ($finalUrl -match "/versions/([^/]+)/") {
           $version = $Matches[1]
           echo "version=$version" >> $env:GITHUB_OUTPUT
           Write-Host "Latest Twingate version: $version"
         } else {
-          throw "Could not parse version from Location header: $location"
+          throw "Could not parse version from URL: $finalUrl"
         }
 
     - name: Cache Twingate package (Windows)


### PR DESCRIPTION
Resolves #48 

## Changes

Cache the .deb file on linux install

Timing before change (see this [run](https://github.com/Twingate/github-action/pull/56)):
- ubuntu-latest - 25s
- ubuntu-2404 - 21s
- ubuntu-2204 - 22s

Timing After change (see this [run](https://github.com/Twingate/github-action/actions/runs/20385449978)):
- ubuntu-latest - 14s
- ubuntu-2404 - 14s
- ubuntu-2204 - 15s

