### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       timeout-minutes: 5
       steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
         - uses: ./
           with:
@@ -82,7 +82,7 @@ jobs:
         options: --privileged
       timeout-minutes: 10
       steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
         - uses: ./
           with:
@@ -123,7 +123,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       timeout-minutes: 6
       steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
         - uses: ./
           with:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           exempt-pr-labels: 'pinned,security,dependencies'

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Cache Twingate package and dependencies (Linux)
       if: runner.os == 'Linux' && inputs.cache == 'true' && steps.twingate-version-linux.outputs.version != 'unknown'
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: cache-twingate-linux
       with:
         path: ~/.twingate-cache
@@ -101,7 +101,7 @@ runs:
 
     - name: Cache Twingate MSI (Windows)
       if: runner.os == 'Windows' && inputs.cache == 'true' && steps.twingate-version-windows.outputs.version != 'unknown'
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: cache-twingate-windows
       with:
         path: ${{ runner.temp }}\twingate-cache


### PR DESCRIPTION
## Summary
- Pin `actions/checkout@v6` to `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- Pin `actions/cache@v5` to `actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7` (v5.0.4)
- Pin `actions/stale@v10` to `actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f` (v10.2.0)

Mutable version tags can be overwritten in a supply chain attack. Pinning to commit SHAs ensures we always run the exact code we reviewed.

## Test plan
- [ ] CI workflows pass with pinned SHAs
- [ ] Verify action.yml cache steps still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)