### PR TITLE
chore: replace docker:// with docker run in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,13 +57,13 @@ jobs:
 
         - name: Access a secure resource from a docker
           run: |
-            docker run --rm --network host alpine:3.19 /bin/sh -c "
-              sed '/^nameserver 168.63.129.16$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf &&
+            docker run --rm --network host alpine:3.19 /bin/sh -c '
+              sed "/^nameserver 168.63.129.16$/d; /^search/d" /etc/resolv.conf > /tmp/resolv.conf &&
               cat /tmp/resolv.conf > /etc/resolv.conf &&
               cat /etc/resolv.conf &&
               apk add --no-cache curl &&
               curl -v http://business.prod.beamreachinc.int/
-            "
+            '
 
         - name: Print client logs
           if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
 
         - name: Access a secure resource from a docker
           run: |
-            docker run --rm --network host alpine:3.19 /bin/sh -c '
+            docker run --rm --network host alpine:3.21 /bin/sh -c '
               sed "/^nameserver 168.63.129.16$/d; /^search/d" /etc/resolv.conf > /tmp/resolv.conf &&
               cat /tmp/resolv.conf > /etc/resolv.conf &&
               cat /etc/resolv.conf &&

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
             curl -v $TEST_URL
 
         - name: Access a secure resource from a docker
-          uses: docker://alpine:latest
+          uses: docker://alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
           id: test_docker_curl
           with:
             entrypoint: /bin/sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,18 +56,14 @@ jobs:
             curl -v $TEST_URL
 
         - name: Access a secure resource from a docker
-          uses: docker://alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-          id: test_docker_curl
-          with:
-            entrypoint: /bin/sh
-            args: |
-              -c "
-                sed '/^nameserver 168.63.129.16$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf && 
-                cat /tmp/resolv.conf > /etc/resolv.conf && 
-                cat /etc/resolv.conf && 
-                apk update && apk add curl && 
-                curl -v http://business.prod.beamreachinc.int/
-              "
+          run: |
+            docker run --rm --network host alpine:latest /bin/sh -c "
+              sed '/^nameserver 168.63.129.16$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf &&
+              cat /tmp/resolv.conf > /etc/resolv.conf &&
+              cat /etc/resolv.conf &&
+              apk update && apk add curl &&
+              curl -v http://business.prod.beamreachinc.int/
+            "
 
         - name: Print client logs
           if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
 
         - name: Access a secure resource from a docker
           run: |
-            docker run --rm --network host alpine:latest /bin/sh -c "
+            docker run --rm --network host alpine:3.19 /bin/sh -c "
               sed '/^nameserver 168.63.129.16$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf &&
               cat /tmp/resolv.conf > /etc/resolv.conf &&
               cat /etc/resolv.conf &&

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
               sed '/^nameserver 168.63.129.16$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf &&
               cat /tmp/resolv.conf > /etc/resolv.conf &&
               cat /etc/resolv.conf &&
-              apk update && apk add curl &&
+              apk add --no-cache curl &&
               curl -v http://business.prod.beamreachinc.int/
             "
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.secrets
+/.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Replace `uses: docker://alpine@sha256:...` with an explicit `docker run --rm --network host` command
- Gives more control over container execution and avoids the `docker://` action pattern

## Test plan
- [ ] CI workflow passes — the docker step should still curl the secure resource successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)