### PR TITLE
fix: fail fast on container runners lacking NET_ADMIN (OSS-123)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -223,6 +223,11 @@ runs:
         source "$GITHUB_ACTION_PATH/scripts/linux-helpers.sh"
 
         echo '${{ inputs.service-key }}' | $SUDO twingate setup --headless -
+
+        # Fail fast on runners that fundamentally can't run a VPN client
+        # (e.g. ubuntu-slim), instead of retrying silently until timeout.
+        check_network_capabilities || exit 1
+
         MAX_RETRIES=5
         WAIT_TIME=5
         n=0
@@ -247,7 +252,14 @@ runs:
           else
             twingate stop
             if [ "${{ inputs.debug }}" = "true" ]; then
-              journalctl -u twingate --no-pager
+              # journalctl is empty without systemd (container runners); the
+              # forked daemon logs to /var/log/twingated.log instead.
+              if [ -d /run/systemd/system ]; then
+                journalctl -u twingate --no-pager
+              else
+                log INFO "systemd not present; dumping /var/log/twingated.log"
+                $SUDO cat /var/log/twingated.log 2>/dev/null || log INFO "no daemon log found"
+              fi
             fi
           fi
 

--- a/scripts/linux-helpers.sh
+++ b/scripts/linux-helpers.sh
@@ -34,8 +34,9 @@ get_os_version() {
 # Verify the runner can actually run a VPN client before we try to start it.
 # Twingate needs the TUN device node AND CAP_NET_ADMIN (for ioctl(TUNSETIFF) and
 # route setup). Unprivileged container runners (ubuntu-slim, some container jobs)
-# have neither, so the daemon starts but never comes online. Fail fast with
-# guidance instead of retrying silently for ~75s. Returns non-zero if unusable.
+# lack at least one of these — often the TUN node exists but CAP_NET_ADMIN is
+# dropped — so the daemon starts but never comes online. Fail fast with guidance
+# instead of retrying silently for ~75s. Returns non-zero if unusable.
 check_network_capabilities() {
   local missing=""
 
@@ -45,7 +46,9 @@ check_network_capabilities() {
   # absent there, not even root (via sudo) can acquire it. If CapBnd is
   # unreadable we skip this check rather than risk a false failure.
   local cap_bnd
-  cap_bnd=$(awk '/^CapBnd:/ {print $2}' /proc/self/status 2>/dev/null)
+  # `|| true` so an unreadable /proc/self/status yields "" instead of tripping
+  # `set -e` in the calling step (this runs before the loop's `set +xe`).
+  cap_bnd=$(awk '/^CapBnd:/ {print $2}' /proc/self/status 2>/dev/null || true)
   if [ -n "$cap_bnd" ] && [ $(( (0x$cap_bnd >> 12) & 1 )) -ne 1 ]; then
     missing="$missing CAP_NET_ADMIN"
   fi

--- a/scripts/linux-helpers.sh
+++ b/scripts/linux-helpers.sh
@@ -31,6 +31,37 @@ get_os_version() {
   grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"'
 }
 
+# Verify the runner can actually run a VPN client before we try to start it.
+# Twingate needs the TUN device node AND CAP_NET_ADMIN (for ioctl(TUNSETIFF) and
+# route setup). Unprivileged container runners (ubuntu-slim, some container jobs)
+# have neither, so the daemon starts but never comes online. Fail fast with
+# guidance instead of retrying silently for ~75s. Returns non-zero if unusable.
+check_network_capabilities() {
+  local missing=""
+
+  [ -e /dev/net/tun ] || missing="$missing /dev/net/tun"
+
+  # CAP_NET_ADMIN is capability bit 12. CapBnd is the bounding set: if the cap is
+  # absent there, not even root (via sudo) can acquire it. If CapBnd is
+  # unreadable we skip this check rather than risk a false failure.
+  local cap_bnd
+  cap_bnd=$(awk '/^CapBnd:/ {print $2}' /proc/self/status 2>/dev/null)
+  if [ -n "$cap_bnd" ] && [ $(( (0x$cap_bnd >> 12) & 1 )) -ne 1 ]; then
+    missing="$missing CAP_NET_ADMIN"
+  fi
+
+  if [ -n "$missing" ]; then
+    log ERROR "Twingate needs a TUN device and CAP_NET_ADMIN, but this runner is missing:$missing"
+    log ERROR "This is expected on minimal/unprivileged container runners such as ubuntu-slim."
+    log ERROR "For container jobs, grant them via your job's container config:"
+    log ERROR "    container:"
+    log ERROR "      options: --cap-add NET_ADMIN --device /dev/net/tun"
+    log ERROR "See https://www.twingate.com/docs/linux-headless/#working-with-the-linux-client-in-headless-mode"
+    return 1
+  fi
+  return 0
+}
+
 validate_cache_linux() {
   local deb_file
   deb_file=$(ls ~/.twingate-cache/twingate*.deb 2>/dev/null | head -1)


### PR DESCRIPTION
## Problem

The action fails on `ubuntu-slim` and other minimal/unprivileged container runners (e.g. `blacksmith-4vcpu-ubuntu-2404`), reported in #76 / OSS-123. The client installs fine, but `twingate start` loops on `status: 'not-running'` for ~75s and then exits 1 with a generic "Twingate service failed to connect."

## Root cause

Twingate is a VPN — it must create and configure a TUN interface, which requires the `CAP_NET_ADMIN` capability. These runners execute the job in an unprivileged container that drops `NET_ADMIN` from its capability set.

- `/dev/net/tun` *does* exist on these runners, so the client's existing device-node check passes (which is why the "docker run must be run with `--cap-add NET_ADMIN`" hint never appears).
- With no systemd in the container, the client forks the daemon directly and returns success ("Twingate has been started").
- Inside the forked daemon, `ioctl(tun_fd, TUNSETIFF)` fails without `CAP_NET_ADMIN`, so the interface is never created and the tunnel never comes online.
- The daemon's error goes to `/var/log/twingated.log`, but the action's debug branch runs `journalctl -u twingate`, which is empty without systemd — so the failure is invisible.

## Changes

- **`scripts/linux-helpers.sh`** — new `check_network_capabilities()`: verifies `/dev/net/tun` and `CAP_NET_ADMIN` (parsed from the `CapBnd` bounding set in `/proc/self/status`, bit 12). Prints actionable guidance when missing. Skips the cap check if `CapBnd` is unreadable (no false failures).
- **`action.yml`** — calls it right after `setup`, before the retry loop, to **fail fast with guidance** instead of retrying silently. Also dumps `/var/log/twingated.log` in debug mode when systemd is absent.

## What this does / doesn't fix

- Container **jobs** the user controls: the error now tells them to add `container.options: --cap-add NET_ADMIN --device /dev/net/tun`.
- GitHub-hosted `ubuntu-slim`: no way to add capabilities, so Twingate still cannot run there — but the action now fails immediately with a clear reason instead of a 75s silent timeout.

## Testing

Capability bit extraction verified against known cap sets:

| CapBnd | NET_ADMIN (bit 12) |
|---|---|
| `000001ffffffffff` (full) | ✅ present |
| `0000003fffffffff` (VM runner) | ✅ present |
| `00000000a80425fb` (Docker default) | ❌ dropped → flagged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)