### PR TITLE
fix: retry transient 401 when fetching APT signing key (#86)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,8 +167,7 @@ runs:
       run: |
         source "$GITHUB_ACTION_PATH/scripts/linux-helpers.sh"
 
-        # Import Twingate GPG key for signature verification
-        curl -fsSL https://packages.twingate.com/apt/gpg.key | $SUDO gpg --batch --yes --no-tty --dearmor -o /usr/share/keyrings/twingate-client-keyring.gpg
+        install_twingate_gpg_key
 
         # Add Twingate repository with GPG key verification
         echo "deb [signed-by=/usr/share/keyrings/twingate-client-keyring.gpg] https://packages.twingate.com/apt/ * *" | $SUDO tee /etc/apt/sources.list.d/twingate.list

--- a/scripts/linux-helpers.sh
+++ b/scripts/linux-helpers.sh
@@ -45,10 +45,13 @@ install_twingate_gpg_key() {
     return 1
   fi
 
-  $SUDO gpg --batch --yes --no-tty --dearmor -o "$keyring" < "$tmp"
-  local rc=$?
+  if ! $SUDO gpg --batch --yes --no-tty --dearmor -o "$keyring" < "$tmp"; then
+    log ERROR "Failed to install Twingate GPG key (gpg --dearmor failed)."
+    rm -f "$tmp"
+    return 1
+  fi
   rm -f "$tmp"
-  return $rc
+  return 0
 }
 
 # Verify the runner can actually run a VPN client before we try to start it.

--- a/scripts/linux-helpers.sh
+++ b/scripts/linux-helpers.sh
@@ -31,6 +31,26 @@ get_os_version() {
   grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"'
 }
 
+# Fetch/install the Twingate APT signing key, retrying transient 401s (issue #86).
+# Write to a temp file so a failure surfaces curl's status, not gpg's empty-body error.
+install_twingate_gpg_key() {
+  local keyring=/usr/share/keyrings/twingate-client-keyring.gpg
+  local tmp
+  tmp=$(mktemp)
+
+  if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+       https://packages.twingate.com/apt/gpg.key -o "$tmp"; then
+    log ERROR "Failed to download Twingate GPG key from https://packages.twingate.com/apt/gpg.key after retries (see curl error above)."
+    rm -f "$tmp"
+    return 1
+  fi
+
+  $SUDO gpg --batch --yes --no-tty --dearmor -o "$keyring" < "$tmp"
+  local rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
 # Verify the runner can actually run a VPN client before we try to start it.
 # Twingate needs the TUN device node AND CAP_NET_ADMIN (for ioctl(TUNSETIFF) and
 # route setup). Unprivileged container runners (ubuntu-slim, some container jobs)


### PR DESCRIPTION
## Problem

`https://packages.twingate.com/apt/gpg.key` intermittently returns **HTTP 401**, breaking the Linux install step (issue #86). The old command piped `curl -f` straight into gpg:

```bash
curl -fsSL .../gpg.key | gpg --dearmor -o .../twingate-client-keyring.gpg
```

On a 401, `curl -f` emits an empty body, so gpg fails with `no valid OpenPGP data found` and the step exits with code 2. It's intermittent — a re-run succeeds unchanged.

## Fix

Move the fetch into `install_twingate_gpg_key()` in `scripts/linux-helpers.sh`:

- **Retry** with `curl --retry 5 --retry-all-errors --retry-delay 2` — `--retry-all-errors` covers HTTP 401 (curl 7.71+; runners ship 8.x).
- **Download to a temp file** and check curl's exit before invoking gpg, so a final failure surfaces curl's HTTP status instead of gpg's misleading empty-body error.
