### PR TITLE
fix(windows): stop CI timeouts from slow MSI download and dead cache (OSS-173)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,7 +195,10 @@ runs:
         $env:DEBUG_MODE = '${{ inputs.debug }}'
         . "$env:GITHUB_ACTION_PATH/scripts/windows-helpers.ps1"
 
-        # Download MSI
+        # Download MSI. Windows PowerShell 5.1 renders a progress bar per chunk for
+        # -OutFile, which throttles the transfer to ~100KB/s and pushed this step past
+        # the job timeout; suppressing it brings the 30MB download back to seconds.
+        $ProgressPreference = 'SilentlyContinue'
         $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
         log DEBUG "Downloading Twingate from $msiUrl"
         Invoke-WebRequest -Uri $msiUrl -OutFile ".\twingate_client.msi"

--- a/action.yml
+++ b/action.yml
@@ -195,9 +195,6 @@ runs:
         $env:DEBUG_MODE = '${{ inputs.debug }}'
         . "$env:GITHUB_ACTION_PATH/scripts/windows-helpers.ps1"
 
-        # Download MSI. Windows PowerShell 5.1 renders a progress bar per chunk for
-        # -OutFile, which throttles the transfer to ~100KB/s and pushed this step past
-        # the job timeout; suppressing it brings the 30MB download back to seconds.
         $ProgressPreference = 'SilentlyContinue'
         $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
         log DEBUG "Downloading Twingate from $msiUrl"

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -14,18 +14,14 @@ function Get-TwingateVersion {
     $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
     log DEBUG "Fetching from $msiUrl"
 
-    # The download URL redirects twice (api.twingate.com -> api.<region>.twingate.com
-    # -> binaries.twingate.com/.../versions/<x.y.z>/...), and only the last hop carries
-    # the version. HEAD follows the whole chain without pulling down the 30MB body.
-    $ProgressPreference = 'SilentlyContinue'
     $response = Invoke-WebRequest -Uri $msiUrl -Method Head -UseBasicParsing
 
-    # Windows PowerShell 5.1 exposes the resolved URI as BaseResponse.ResponseUri;
-    # PowerShell 6+ swaps in HttpClient, where it is RequestMessage.RequestUri.
-    $finalUrl = if ($response.BaseResponse.ResponseUri) {
-      $response.BaseResponse.ResponseUri.AbsoluteUri
+    # 5.1 returns HttpWebResponse (ResponseUri); 6+ uses HttpClient (RequestMessage.RequestUri).
+    $base = $response.BaseResponse
+    $finalUrl = if ($base -is [System.Net.HttpWebResponse]) {
+      $base.ResponseUri.AbsoluteUri
     } else {
-      $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+      $base.RequestMessage.RequestUri.AbsoluteUri
     }
 
     log DEBUG "Resolved download URL: $finalUrl"

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -14,10 +14,21 @@ function Get-TwingateVersion {
     $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
     log DEBUG "Fetching from $msiUrl"
 
-    $response = Invoke-WebRequest -Uri $msiUrl -Method Get -UseBasicParsing -MaximumRedirection 0 -ErrorAction SilentlyContinue
-    $finalUrl = $response.Headers.Location
+    # The download URL redirects twice (api.twingate.com -> api.<region>.twingate.com
+    # -> binaries.twingate.com/.../versions/<x.y.z>/...), and only the last hop carries
+    # the version. HEAD follows the whole chain without pulling down the 30MB body.
+    $ProgressPreference = 'SilentlyContinue'
+    $response = Invoke-WebRequest -Uri $msiUrl -Method Head -UseBasicParsing
 
-    log DEBUG "Redirect location: $finalUrl"
+    # Windows PowerShell 5.1 exposes the resolved URI as BaseResponse.ResponseUri;
+    # PowerShell 6+ swaps in HttpClient, where it is RequestMessage.RequestUri.
+    $finalUrl = if ($response.BaseResponse.ResponseUri) {
+      $response.BaseResponse.ResponseUri.AbsoluteUri
+    } else {
+      $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+    }
+
+    log DEBUG "Resolved download URL: $finalUrl"
 
     if ($finalUrl -match 'versions/([\d.]+)/') {
       $version = $matches[1]


### PR DESCRIPTION
Fixes [OSS-173](https://linear.app/twingate/issue/OSS-173/windows-ci-jobs-intermittently-hit-the-6m-timeout-msi-download-is-slow).

`test-windows` jobs were cancelled by the 6-minute `timeout-minutes` roughly 25% of the time — 3 of the last 12 hourly runs on `main` ([34430201814](https://github.com/Twingate/github-action/actions/runs/34430201814), [34422115446](https://github.com/Twingate/github-action/actions/runs/34422115446), [34390192210](https://github.com/Twingate/github-action/actions/runs/34390192210)). Always during **"Download and cache Twingate MSI (Windows)"**; never an actual test failure. Two independent defects combined.

## 1. `Get-TwingateVersion` always returned `unknown`, so the Windows cache never worked

It resolved the download URL with `-MaximumRedirection 0` and read a single `Location` header — but the URL redirects **twice**, and only the last hop carries the version:

```
https://api.twingate.com/download/windows?installer=msi
  -> 307 https://api.us1.twingate.com/download/windows?installer=msi          <- only hop it saw
  -> 302 https://binaries.twingate.com/client/windows/versions/2026.239.5147/TwingateWindowsInstaller.msi
```

The `versions/([\d.]+)/` regex never matched, so the function returned `"unknown"`. That value gates every Windows cache step (`action.yml:103`), so cache save/restore/validate/copy were all skipped — **no Windows run has ever hit the cache** since they were added. Confirmed across windows-2022, windows-2025 and windows-latest, where the download step's own guard renders as the literal no-op `if ('unknown' -ne 'unknown')`. It stayed invisible because every diagnostic on that path is `log DEBUG` and `debug` defaults to `false`.

Now resolved with a `HEAD` request that follows the whole chain without pulling the body. Dropping `-ErrorAction SilentlyContinue` also lets genuine network errors reach the existing `catch` instead of silently yielding `$null`.

## 2. The download ran at ~100–170 KB/s

30 MB (`content-length: 31531008`) taking 180–308s. Windows PowerShell 5.1 renders a progress bar per chunk for `Invoke-WebRequest -OutFile`, which throttles the transfer; `$ProgressPreference = 'SilentlyContinue'` removes it.

Per-job download duration in the failing run — note how little headroom there was even on the passing jobs:

| job | download step | result |
| --- | --- | --- |
| windows-latest | 180s | pass |
| windows-2025 | 219s | pass |
| windows-2022 | **308s** | **cancelled at 6m** |

## Why both

They're independent and both needed: fixing only the cache still leaves a cold run near the timeout; fixing only `$ProgressPreference` stops the flake but leaves the cache dead.

## Verification

- Confirmed the redirect chain and that `HEAD` returns 200 at the final versioned URL.
- Confirmed the unchanged regex extracts `2026.239.5147` from that URL — matching `app_version=2026.239.5147` in the passing runs' client logs.
- `action.yml` still parses.
- The URL extraction handles both PS editions (5.1 `BaseResponse.ResponseUri`, PS 6+ `RequestMessage.RequestUri`); all steps pin `shell: powershell` (5.1) today.
- CI on this PR is the real test — it exercises the Windows cache path for the first time. Worth a second run once merged to confirm a warm cache hit.

I did **not** raise `timeout-minutes`; it should no longer be the binding constraint, and leaving it at 6 keeps the regression visible if either fix stops working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)