### PR TITLE
fix(windows): actually validate the cached MSI (OSS-174)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,7 +195,10 @@ runs:
         $env:DEBUG_MODE = '${{ inputs.debug }}'
         . "$env:GITHUB_ACTION_PATH/scripts/windows-helpers.ps1"
 
-        # Download MSI
+        # Download MSI. Windows PowerShell 5.1 renders a progress bar per chunk for
+        # -OutFile, which throttles the transfer to ~100KB/s and pushed this step past
+        # the job timeout; suppressing it brings the 30MB download back to seconds.
+        $ProgressPreference = 'SilentlyContinue'
         $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
         log DEBUG "Downloading Twingate from $msiUrl"
         Invoke-WebRequest -Uri $msiUrl -OutFile ".\twingate_client.msi"

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
         . "$env:GITHUB_ACTION_PATH/scripts/windows-helpers.ps1"
 
         $cacheDir = "${{ runner.temp }}\twingate-cache"
-        $isValid = Validate-CacheWindows -CacheDir $cacheDir
+        $isValid = Validate-CacheWindows -CacheDir $cacheDir -ExpectedVersion '${{ steps.twingate-version-windows.outputs.version }}'
         Add-Content -Path $env:GITHUB_OUTPUT -Value "valid=$isValid"
 
     - name: Install Twingate from cache (Linux)

--- a/scripts/linux-helpers.sh
+++ b/scripts/linux-helpers.sh
@@ -19,7 +19,7 @@ get_twingate_version() {
   version=$(curl -sf https://packages.twingate.com/apt/Packages | awk '/^Package: twingate$/,/^Version:/ {if (/^Version:/) print $2}' | sort -V | tail -1)
 
   if [ -z "$version" ]; then
-    log DEBUG "Failed to fetch version, proceeding without cache"
+    log WARNING "Failed to fetch version, proceeding without cache"
     echo "unknown"
   else
     log DEBUG "Latest Twingate version: $version"
@@ -93,10 +93,10 @@ validate_cache_linux() {
   deb_file=$(ls ~/.twingate-cache/twingate*.deb 2>/dev/null | head -1)
 
   if [ -z "$deb_file" ]; then
-    log DEBUG "No .deb file found in cache"
+    log WARNING "Cache was restored but contains no .deb, reinstalling from apt"
     echo "false"
   elif ! dpkg-deb --info "$deb_file" >/dev/null 2>&1; then
-    log DEBUG "Cached .deb is corrupted"
+    log WARNING "Cached .deb is corrupted, reinstalling from apt"
     rm -rf ~/.twingate-cache/*
     echo "false"
   else

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -52,7 +52,7 @@ function Get-OSVersion {
 }
 
 function Validate-CacheWindows {
-  param([string]$CacheDir)
+  param([string]$CacheDir, [string]$ExpectedVersion)
 
   $msiFiles = Get-ChildItem -Path $CacheDir -Filter "twingate*.msi" -ErrorAction SilentlyContinue
 
@@ -61,22 +61,60 @@ function Validate-CacheWindows {
     return $false
   }
 
-  try {
-    $msiFile = $msiFiles[0].FullName
+  $msiFile = $msiFiles[0].FullName
+  $installer = $null
+  $database = $null
+  $view = $null
+  $record = $null
 
-    # Try to get MSI properties - this validates the MSI file
-    $msiInfo = Get-ItemProperty -Path $msiFile
-    if (-not $msiInfo) {
-      log DEBUG "Cached MSI is corrupted"
-      Remove-Item -Path $CacheDir -Recurse -Force -ErrorAction SilentlyContinue
+  try {
+    # OpenDatabase parses the MSI, so a truncated or corrupt file throws here rather
+    # than surviving to msiexec. Mode 0 is read-only.
+    $installer = New-Object -ComObject WindowsInstaller.Installer
+    $database = $installer.GetType().InvokeMember('OpenDatabase', 'InvokeMethod', $null, $installer, @($msiFile, 0))
+
+    # ProductVersion is not usable for this check: MSI caps the major field at 255, so
+    # a client version like 2026.239.5147 is stored as 20.26.239.5147. ProductName
+    # ("Twingate <version>") carries the upstream version verbatim.
+    $view = $database.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $database,
+      @("SELECT Value FROM Property WHERE Property = 'ProductName'"))
+    $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null) | Out-Null
+    $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
+
+    if ($null -eq $record) {
+      log DEBUG "Cached MSI has no ProductName property"
+      Clear-CacheWindows -CacheDir $CacheDir
       return $false
-    } else {
-      log DEBUG "Cache is valid"
-      return $true
     }
+
+    $productName = $record.GetType().InvokeMember('StringData', 'GetProperty', $null, $record, @(1))
+    log DEBUG "Cached MSI ProductName: $productName"
+
+    if ($ExpectedVersion -and $ExpectedVersion -ne 'unknown' -and
+        $productName -notmatch ('\b' + [regex]::Escape($ExpectedVersion) + '\b')) {
+      log DEBUG "Cached MSI is version-mismatched (wanted $ExpectedVersion)"
+      Clear-CacheWindows -CacheDir $CacheDir
+      return $false
+    }
+
+    log DEBUG "Cache is valid"
+    return $true
   } catch {
     log DEBUG "Cached MSI is corrupted: $_"
-    Remove-Item -Path $CacheDir -Recurse -Force -ErrorAction SilentlyContinue
+    Clear-CacheWindows -CacheDir $CacheDir
     return $false
+  } finally {
+    # Release the COM handles so nothing holds the MSI open for the copy that follows.
+    foreach ($obj in @($record, $view, $database, $installer)) {
+      if ($obj) { [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($obj) }
+    }
   }
+}
+
+function Clear-CacheWindows {
+  param([string]$CacheDir)
+
+  # Clear the contents but keep the directory, matching validate_cache_linux and
+  # leaving the path in place for the download step and the cache save.
+  Remove-Item -Path (Join-Path $CacheDir '*') -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -14,18 +14,14 @@ function Get-TwingateVersion {
     $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
     log DEBUG "Fetching from $msiUrl"
 
-    # The download URL redirects twice (api.twingate.com -> api.<region>.twingate.com
-    # -> binaries.twingate.com/.../versions/<x.y.z>/...), and only the last hop carries
-    # the version. HEAD follows the whole chain without pulling down the 30MB body.
-    $ProgressPreference = 'SilentlyContinue'
     $response = Invoke-WebRequest -Uri $msiUrl -Method Head -UseBasicParsing
 
-    # Windows PowerShell 5.1 exposes the resolved URI as BaseResponse.ResponseUri;
-    # PowerShell 6+ swaps in HttpClient, where it is RequestMessage.RequestUri.
-    $finalUrl = if ($response.BaseResponse.ResponseUri) {
-      $response.BaseResponse.ResponseUri.AbsoluteUri
+    # 5.1 returns HttpWebResponse (ResponseUri); 6+ uses HttpClient (RequestMessage.RequestUri).
+    $base = $response.BaseResponse
+    $finalUrl = if ($base -is [System.Net.HttpWebResponse]) {
+      $base.ResponseUri.AbsoluteUri
     } else {
-      $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+      $base.RequestMessage.RequestUri.AbsoluteUri
     }
 
     log DEBUG "Resolved download URL: $finalUrl"

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -14,10 +14,21 @@ function Get-TwingateVersion {
     $msiUrl = "https://api.twingate.com/download/windows?installer=msi"
     log DEBUG "Fetching from $msiUrl"
 
-    $response = Invoke-WebRequest -Uri $msiUrl -Method Get -UseBasicParsing -MaximumRedirection 0 -ErrorAction SilentlyContinue
-    $finalUrl = $response.Headers.Location
+    # The download URL redirects twice (api.twingate.com -> api.<region>.twingate.com
+    # -> binaries.twingate.com/.../versions/<x.y.z>/...), and only the last hop carries
+    # the version. HEAD follows the whole chain without pulling down the 30MB body.
+    $ProgressPreference = 'SilentlyContinue'
+    $response = Invoke-WebRequest -Uri $msiUrl -Method Head -UseBasicParsing
 
-    log DEBUG "Redirect location: $finalUrl"
+    # Windows PowerShell 5.1 exposes the resolved URI as BaseResponse.ResponseUri;
+    # PowerShell 6+ swaps in HttpClient, where it is RequestMessage.RequestUri.
+    $finalUrl = if ($response.BaseResponse.ResponseUri) {
+      $response.BaseResponse.ResponseUri.AbsoluteUri
+    } else {
+      $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+    }
+
+    log DEBUG "Resolved download URL: $finalUrl"
 
     if ($finalUrl -match 'versions/([\d.]+)/') {
       $version = $matches[1]

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -54,20 +54,23 @@ function Get-OSVersion {
 function Validate-CacheWindows {
   param([string]$CacheDir, [string]$ExpectedVersion)
 
-  $msiFiles = Get-ChildItem -Path $CacheDir -Filter "twingate*.msi" -ErrorAction SilentlyContinue
+  # @() so Count is reliable even when Get-ChildItem finds nothing or is silenced.
+  $msiFiles = @(Get-ChildItem -Path $CacheDir -Filter "twingate*.msi" -ErrorAction SilentlyContinue)
 
   if ($msiFiles.Count -eq 0) {
     log WARNING "Cache was restored but contains no MSI, re-downloading"
     return $false
   }
 
-  $msiFile = $msiFiles[0].FullName
   $installer = $null
   $database = $null
   $view = $null
   $record = $null
+  $invalidReason = $null
 
   try {
+    $msiFile = $msiFiles[0].FullName
+
     # OpenDatabase parses the MSI, so a truncated or corrupt file throws here rather
     # than surviving to msiexec. Mode 0 is read-only.
     $installer = New-Object -ComObject WindowsInstaller.Installer
@@ -82,33 +85,36 @@ function Validate-CacheWindows {
     $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
 
     if ($null -eq $record) {
-      log WARNING "Cached MSI has no ProductName property, re-downloading"
-      Clear-CacheWindows -CacheDir $CacheDir
-      return $false
+      $invalidReason = "Cached MSI has no ProductName property"
+    } else {
+      $productName = $record.GetType().InvokeMember('StringData', 'GetProperty', $null, $record, @(1))
+      log DEBUG "Cached MSI ProductName: $productName"
+
+      # Compare the trailing version token exactly. A substring or word-boundary match
+      # would accept 2026.239.5147.1 as 2026.239.5147, letting a different build pass.
+      $cachedVersion = if ($productName -match '(\d+(?:\.\d+)+)\s*$') { $matches[1] } else { '' }
+
+      if ($ExpectedVersion -and $ExpectedVersion -ne 'unknown' -and $cachedVersion -ne $ExpectedVersion) {
+        $invalidReason = "Cached MSI is version-mismatched (wanted $ExpectedVersion, found '$cachedVersion')"
+      }
     }
-
-    $productName = $record.GetType().InvokeMember('StringData', 'GetProperty', $null, $record, @(1))
-    log DEBUG "Cached MSI ProductName: $productName"
-
-    if ($ExpectedVersion -and $ExpectedVersion -ne 'unknown' -and
-        $productName -notmatch ('\b' + [regex]::Escape($ExpectedVersion) + '\b')) {
-      log WARNING "Cached MSI is version-mismatched (wanted $ExpectedVersion), re-downloading"
-      Clear-CacheWindows -CacheDir $CacheDir
-      return $false
-    }
-
-    log DEBUG "Cache is valid"
-    return $true
   } catch {
-    log WARNING "Cached MSI is corrupted, re-downloading: $_"
-    Clear-CacheWindows -CacheDir $CacheDir
-    return $false
+    $invalidReason = "Cached MSI is corrupted: $_"
   } finally {
-    # Release the COM handles so nothing holds the MSI open for the copy that follows.
+    # Release the COM handles before any cleanup below, so nothing holds the MSI open.
     foreach ($obj in @($record, $view, $database, $installer)) {
       if ($obj) { [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($obj) }
     }
   }
+
+  if ($invalidReason) {
+    log WARNING "$invalidReason, re-downloading"
+    Clear-CacheWindows -CacheDir $CacheDir
+    return $false
+  }
+
+  log DEBUG "Cache is valid"
+  return $true
 }
 
 function Clear-CacheWindows {

--- a/scripts/windows-helpers.ps1
+++ b/scripts/windows-helpers.ps1
@@ -31,11 +31,11 @@ function Get-TwingateVersion {
       log DEBUG "Latest Twingate version: $version"
       return $version
     } else {
-      log DEBUG "Could not extract version from URL"
+      log WARNING "Could not extract version from download URL, proceeding without cache"
       return "unknown"
     }
   } catch {
-    log DEBUG "Error: $_"
+    log WARNING "Version detection failed, proceeding without cache: $_"
     return "unknown"
   }
 }
@@ -57,7 +57,7 @@ function Validate-CacheWindows {
   $msiFiles = Get-ChildItem -Path $CacheDir -Filter "twingate*.msi" -ErrorAction SilentlyContinue
 
   if ($msiFiles.Count -eq 0) {
-    log DEBUG "No MSI file found in cache"
+    log WARNING "Cache was restored but contains no MSI, re-downloading"
     return $false
   }
 
@@ -82,7 +82,7 @@ function Validate-CacheWindows {
     $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
 
     if ($null -eq $record) {
-      log DEBUG "Cached MSI has no ProductName property"
+      log WARNING "Cached MSI has no ProductName property, re-downloading"
       Clear-CacheWindows -CacheDir $CacheDir
       return $false
     }
@@ -92,7 +92,7 @@ function Validate-CacheWindows {
 
     if ($ExpectedVersion -and $ExpectedVersion -ne 'unknown' -and
         $productName -notmatch ('\b' + [regex]::Escape($ExpectedVersion) + '\b')) {
-      log DEBUG "Cached MSI is version-mismatched (wanted $ExpectedVersion)"
+      log WARNING "Cached MSI is version-mismatched (wanted $ExpectedVersion), re-downloading"
       Clear-CacheWindows -CacheDir $CacheDir
       return $false
     }
@@ -100,7 +100,7 @@ function Validate-CacheWindows {
     log DEBUG "Cache is valid"
     return $true
   } catch {
-    log DEBUG "Cached MSI is corrupted: $_"
+    log WARNING "Cached MSI is corrupted, re-downloading: $_"
     Clear-CacheWindows -CacheDir $CacheDir
     return $false
   } finally {


### PR DESCRIPTION
Fixes [OSS-174](https://linear.app/twingate/issue/OSS-174/validate-cachewindows-doesnt-actually-validate-the-cached-msi).

> **Stacked on #91.** Base is the OSS-173 branch, not `main`, because on `main` version detection still returns `unknown`, so the cache steps never run and this code would never execute in CI. Retarget to `main` once #91 merges.

## The defect

`Validate-CacheWindows` returned `$true` for any file that existed:

```powershell
# Try to get MSI properties - this validates the MSI file
$msiInfo = Get-ItemProperty -Path $msiFile
```

The comment states the intent, but `Get-ItemProperty` on a file path returns a `System.IO.FileInfo` (Name, Length, LastWriteTime). It never opens the MSI database, so it is truthy for anything that exists — a 0-byte `twingate-client-x.y.z.msi` passed validation, and both the "corrupt" branch and the `catch` were unreachable. `validate_cache_linux` does this properly via `dpkg-deb --info`, so Windows was the odd one out.

Inert while the Windows cache was dead; live now that #91 has it restoring a 29 MB MSI on every warm run.

## The fix

Open the MSI with `WindowsInstaller.Installer` — `OpenDatabase` parses it and throws on a truncated or corrupt file — then assert the build matches what the cache key promised.

## Why `ProductName` and not `ProductVersion`

This is the part worth reviewing. OSS-174 proposed asserting `ProductVersion` against the cache-key version. **That would have been a bug.** I dumped the Property table of the live MSI:

```
ProductName    = Twingate 2026.239.5147
ProductVersion = 20.26.239.5147     <-- NOT 2026.239.5147
```

MSI caps the `ProductVersion` major field at 255, so `2026` is stored split as `20.26`. Asserting against `ProductVersion` would have failed on **every** run, rejecting every cache entry and silently disabling the cache — precisely the failure mode #91 exists to fix, reintroduced through the back door.

`ProductName` is `Twingate <version>` and carries the upstream string verbatim, so the assertion matches against that instead.

## Also

- COM handles released in a `finally` so nothing holds the MSI open for the `Copy-Item` that follows.
- Failure path now clears the cache directory *contents* rather than removing the *directory*, matching `validate_cache_linux`. Previously the directory removal self-healed only because the download step recreates it; this drops that ordering dependency. (The "secondary nit" in OSS-174.)

## Cost

The user constraint was that this must not add meaningful execution time. `OpenDatabase` reads the MSI's OLE structure, not the ~30 MB cab payload, so it should be cheap. Measured against the `validate-cache-windows` step duration in the #91 runs (353–438 ms baseline) — see the CI result on this PR for the actual delta before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)